### PR TITLE
Renaming for better compatibility with GoA ROM

### DIFF
--- a/mod.yml
+++ b/mod.yml
@@ -14,15 +14,11 @@ assets:
   method: copy
   source:
   - name: obj/W_StarCluster_Final.mdlx
-- name: obj/W_EX010_NM_00.mdlx
+- name: obj/W_EX010_00_NM.mdlx
   method: copy
   source:
   - name: obj/W_StarCluster_Final.mdlx
-- name: obj/W_EX010_TR_00.mdlx
-  method: copy
-  source:
-  - name: obj/W_StarCluster_Final.mdlx
-- name: obj/W_EX010_WI_00.mdlx
+- name: obj/W_EX010_00_TR.mdlx
   method: copy
   source:
   - name: obj/W_StarCluster_Final.mdlx
@@ -30,11 +26,11 @@ assets:
   method: copy
   source:
   - name: remastered/obj/W_EX010.mdlx/-0.dds
-- name: remastered/obj/W_EX010_NM_00.mdlx/-0.dds
+- name: remastered/obj/W_EX010_00_NM.mdlx/-0.dds
   method: copy
   source:
   - name: remastered/obj/W_EX010.mdlx/-1.dds
-- name: remastered/obj/W_EX010_TR_00.mdlx/-0.dds
+- name: remastered/obj/W_EX010_00_TR.mdlx/-0.dds
   method: copy
   source:
   - name: remastered/obj/W_EX010.mdlx/-2.dds
@@ -42,11 +38,11 @@ assets:
   method: copy
   source:
   - name: remastered/obj/W_EX010.a.us/-0.dds
-- name: remastered/obj/W_EX010_NM_00.a.us/-0.dds
+- name: remastered/obj/W_EX010_00_NM.a.us/-0.dds
   method: copy
   source:
   - name: remastered/obj/W_EX010.a.us/-0_NM.dds
-- name: remastered/obj/W_EX010_TR_00.a.us/-0.dds
+- name: remastered/obj/W_EX010_00_TR.a.us/-0.dds
   method: copy
   source:
   - name: remastered/obj/W_EX010.a.us/-0_TR.dds


### PR DESCRIPTION
GoA ROM update renames `W_EX010_NM_00` and  `W_EX010_TR_00` to `W_EX010_00_NM` and  `W_EX01_000_TR` respectively for more consistent naming with the game's scheme.